### PR TITLE
update dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Disfluency Detection, Removal and Correction:
 * **Required Packages:**
     - web.py
     - librosa
-    - tensorflow-gpu (>=1.5)
+    - tensorflow-gpu (>=1.5,<2)
     - pydub
     - pyAudioAnalysis
     - soundfile
@@ -20,7 +20,8 @@ Disfluency Detection, Removal and Correction:
     - scipy
     - numpy
     - sklearn
-    - pickle
+    - matplotlib
+    - hmmlearn
 
 ### Citation
 If you use our tool please consider citing our paper:


### PR DESCRIPTION
updates dependency list in README to reflect:

- it wont work with tensorflow 2 or newer
- `pickle` is a buildin python module and not a package
- matplotlib and hmmlearn are missing